### PR TITLE
Fixes bug app.py

### DIFF
--- a/eapish/app.py
+++ b/eapish/app.py
@@ -89,7 +89,7 @@ def get_config(node, cmd):
     response += gen_hash_string(response)
     return response
 
-def run_cmd(node, config, cmd, encoding):
+def run_cmds(node, config, cmd, encoding):
     if cmd == 'get_configs':
         response = get_config(node, 'startup-config')
         response += get_config(node, 'running-config')
@@ -140,8 +140,6 @@ def main(args=None):
             print 'Error: "%s" connection profile not found' % host
             return 2
 
-        for cmd in cmds.split(','):
-            # Run command and print output
-            run_cmd(node, args.config, cmd, encoding)
+        run_cmds(node, args.config, cmds.split(','), encoding)
 
     return 0

--- a/eapish/app.py
+++ b/eapish/app.py
@@ -89,16 +89,16 @@ def get_config(node, cmd):
     response += gen_hash_string(response)
     return response
 
-def run_cmds(node, config, cmd, encoding):
-    if cmd == 'get_configs':
+def run_cmds(node, config, cmds, encoding):
+    if len(cmds) == 1 and cmds[0] == 'get_configs':
         response = get_config(node, 'startup-config')
         response += get_config(node, 'running-config')
         print response
     else:
         if config:
-            response = node.config(cmd)
+            response = node.config(cmds)
         else:
-            response = node.enable(cmd, encoding=encoding)
+            response = node.enable(cmds, encoding=encoding)
 
         # Print output from command
         print json.dumps(response, sort_keys=True, indent=4,

--- a/test/unit/test_eapish_cmd.py
+++ b/test/unit/test_eapish_cmd.py
@@ -85,7 +85,8 @@ class TestEapish(unittest.TestCase):
         result = eapish.app.main(args)
 
         self.assertEqual(result, 0)
-        node.enable.assert_called_once_with('show vlan', encoding='json')
+        node.enable.assert_called_once_with(['show vlan'], 
+                                            encoding='json')
 
     @patch('pyeapi.connect_to')
     def test_run_cmd_with_enable_and_text(self, pyeapi_mock):
@@ -97,7 +98,8 @@ class TestEapish(unittest.TestCase):
         result = eapish.app.main(args)
 
         self.assertEqual(result, 0)
-        node.enable.assert_called_once_with('show vlan', encoding='text')
+        node.enable.assert_called_once_with(['show vlan'], 
+                                            encoding='text')
 
     @patch('pyeapi.connect_to')
     def test_run_cmd_with_config(self, pyeapi_mock):
@@ -109,7 +111,7 @@ class TestEapish(unittest.TestCase):
         result = eapish.app.main(args)
 
         self.assertEqual(result, 0)
-        node.config.assert_called_once_with('hostname NAME')
+        node.config.assert_called_once_with(['hostname NAME'])
 
     @patch('pyeapi.connect_to')
     def test_run_cmd_with_get_config(self, pyeapi_mock):


### PR DESCRIPTION
In config mode, we want to run all the commands in order and NOT start from config mode each time. Doing that prevents users from configuring anything which has a submode.
